### PR TITLE
Association freq count

### DIFF
--- a/capstone/src/main/java/com/google/sps/AssociationAnalysis.java
+++ b/capstone/src/main/java/com/google/sps/AssociationAnalysis.java
@@ -1,6 +1,8 @@
 package com.google.sps;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 
 /** Calculates association scores from a list of sentiments per entity mention */
 public class AssociationAnalysis {
@@ -8,23 +10,24 @@ public class AssociationAnalysis {
   /** 
    * Calculates association scores for the input array list of mentions
    * @param sentiments array list of sentiments of the mentions
-   * @return the array list of association scores 
+   * @return the array list of association scores sorted by score 
    * */
   public ArrayList<AssociationResult> calculateScores(ArrayList<EntitySentiment> sentiments) {
-    ArrayList<AssociationResult> res = new ArrayList<AssociationResult>();
+    HashMap<String, AssociationResult> res = new HashMap<String, AssociationResult>();
     sentiments.forEach(sentiment -> updateScore(res, sentiment));
-    return res;
+    ArrayList<AssociationResult> list =  new ArrayList(res.values());
+    Collections.sort(list, AssociationResult.ORDER_BY_SCORE);
+    return list;
   }
 
    /** Updates the result array with the new entity mention given */
-  private void updateScore(ArrayList<AssociationResult> res, EntitySentiment sentiment) {
+  private void updateScore(HashMap<String, AssociationResult> res, EntitySentiment sentiment) {
     float scoreDiff = sentiment.getSentiment() * sentiment.getSignificance();
-    for (AssociationResult association : res) {
-      if (association.getContent().equals(sentiment.getContent())) {
-        association.updateScore(association.getScore() + scoreDiff);
-        return;
-      }
+    AssociationResult association = res.get(sentiment.getContent());
+    if (association != null) {
+      association.updateScore(association.getScore() + scoreDiff);
+    } else {
+      res.put(sentiment.getContent(), new AssociationResult(sentiment.getContent(), scoreDiff));
     }
-    res.add(new AssociationResult(sentiment.getContent(), scoreDiff));
   }
 }

--- a/capstone/src/main/java/com/google/sps/AssociationResult.java
+++ b/capstone/src/main/java/com/google/sps/AssociationResult.java
@@ -1,6 +1,7 @@
 package com.google.sps;
 
 import java.lang.Math;
+import java.util.Comparator;
 
 /** Stores the content of an entity along with it association score */
 public class AssociationResult {
@@ -43,6 +44,15 @@ public class AssociationResult {
     score = newScore;
   }
 
+  public static final Comparator<AssociationResult> ORDER_BY_SCORE = 
+    new Comparator<AssociationResult>() {
+      @Override
+      public int compare(AssociationResult a, AssociationResult b) {
+        return Float.compare(a.getScore(), b.getScore());
+      }
+    };
+
+
   @Override
   public String toString() {
     return content + "(" + Float.toString(score) + ")";
@@ -50,9 +60,7 @@ public class AssociationResult {
 
   @Override
   public boolean equals(Object obj) {
-    if (obj == null) {
-      return false;
-    } else if (!AssociationResult.class.isAssignableFrom(obj.getClass())) {
+    if (obj == null || !AssociationResult.class.isAssignableFrom(obj.getClass())) {
       return false;
     }
     AssociationResult x = (AssociationResult) obj;

--- a/capstone/src/test/java/com/google/sps/AssociationAnalysisTest.java
+++ b/capstone/src/test/java/com/google/sps/AssociationAnalysisTest.java
@@ -22,7 +22,7 @@ public class AssociationAnalysisTest extends Mockito{
   }
 
   @Test
-  public void allDistinct() {
+  public void testAllDistinct() {
     ArrayList<EntitySentiment> input = new ArrayList<EntitySentiment>(
         Arrays.asList(new EntitySentiment("test1", 0.5f, 0.5f),
                       new EntitySentiment("test2", 0.9f, -0.6f),
@@ -30,13 +30,13 @@ public class AssociationAnalysisTest extends Mockito{
     AssociationAnalysis analysis = new AssociationAnalysis();
     ArrayList<AssociationResult> res = analysis.calculateScores(input);
     assertEquals(res, new ArrayList(
-        Arrays.asList(new AssociationResult("test1", 0.25f),
-                      new AssociationResult("test2", -0.54f),
-                      new AssociationResult("test3", 0f))));
+        Arrays.asList(new AssociationResult("test2", -0.54f),
+                      new AssociationResult("test3", -0f),
+                      new AssociationResult("test1", 0.25f))));
   }
 
   @Test
-  public void combineTogether() {
+  public void testCombineTogether() {
     ArrayList<EntitySentiment> input = new ArrayList<EntitySentiment>(
         Arrays.asList(new EntitySentiment("test1", 0.5f, 0.5f),
                       new EntitySentiment("test1", 0.9f, 0.6f),
@@ -45,12 +45,12 @@ public class AssociationAnalysisTest extends Mockito{
     AssociationAnalysis analysis = new AssociationAnalysis();
     ArrayList<AssociationResult> res = analysis.calculateScores(input);
     assertEquals(res, new ArrayList(
-        Arrays.asList(new AssociationResult("test1", 0.79f),
-                      new AssociationResult("test2", -1.0f))));
+        Arrays.asList(new AssociationResult("test2", -1.0f),
+                      new AssociationResult("test1", 0.79f))));
   }
 
   @Test
-  public void combineSpreadOut() {
+  public void testCombineSpreadOut() {
     ArrayList<EntitySentiment> input = new ArrayList<EntitySentiment>(
         Arrays.asList(new EntitySentiment("test1", 0.5f, 0.5f),
                       new EntitySentiment("test2", 0.9f, 0.6f),
@@ -65,7 +65,7 @@ public class AssociationAnalysisTest extends Mockito{
   }
 
   @Test
-  public void allSame() {
+  public void testAllSame() {
     ArrayList<EntitySentiment> input = new ArrayList<EntitySentiment>(
         Arrays.asList(new EntitySentiment("test1", 0.5f, 0.5f),
                       new EntitySentiment("test1", 0.9f, 0.6f),
@@ -80,7 +80,7 @@ public class AssociationAnalysisTest extends Mockito{
   }
 
   @Test
-  public void mixedSentiments() {
+  public void testMixedSentiments() {
     ArrayList<EntitySentiment> input = new ArrayList<EntitySentiment>(
         Arrays.asList(new EntitySentiment("test1", 0.5f, -0.5f),
                       new EntitySentiment("test2", 0.9f, 0.6f),
@@ -90,14 +90,14 @@ public class AssociationAnalysisTest extends Mockito{
     AssociationAnalysis analysis = new AssociationAnalysis();
     ArrayList<AssociationResult> res = analysis.calculateScores(input);
     assertEquals(res, new ArrayList(
-        Arrays.asList(new AssociationResult("test1", -0.25f),
-                      new AssociationResult("test2", -0.46f),
+        Arrays.asList(new AssociationResult("test2", -0.46f),
+                      new AssociationResult("test1", -0.25f),
                       new AssociationResult("test3", 0.04f))));
 
   }
 
   @Test(expected=NullPointerException.class)
-  public void nullExceptionThrown() {
+  public void testNullExceptionThrown() {
     AssociationAnalysis analysis = new AssociationAnalysis();
     analysis.calculateScores(null);
   }


### PR DESCRIPTION
New Changes:

Basic association score analysis based on significance in the response and sentiment scores
Cloud NLP to parse entity sentiment from arraylist of open text
Tests for calculation of association score


Copy of old PR because it was accidentally merged too early