### PR TITLE
Association testing

### DIFF
--- a/capstone/pom.xml
+++ b/capstone/pom.xml
@@ -51,6 +51,18 @@
       <version>1.9.64</version>
       <scope>test</scope>
     </dependency>
+      <dependency>
+      <groupId>com.google.appengine</groupId>
+      <artifactId>appengine-api-stubs</artifactId>
+      <version>1.9.64</version>
+      <scope>test</scope>
+    </dependency>
+      <dependency>
+      <groupId>com.google.api-client</groupId>
+      <artifactId>google-api-client-appengine</artifactId>
+      <version>1.23.0</version>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-all</artifactId>

--- a/capstone/src/main/java/com/google/sps/AssociationAnalysis.java
+++ b/capstone/src/main/java/com/google/sps/AssociationAnalysis.java
@@ -8,15 +8,18 @@ import java.util.HashMap;
 public class AssociationAnalysis {
 
   private HashMap<String, AssociationResult> res;
+  private AssociationKey keys;
 
-  public AssociationAnalysis() {
-    res = new HashMap<String, AssociationResult>();
+  public AssociationAnalysis(AssociationKey keys) {
+    this.res = new HashMap<String, AssociationResult>();
+    this.keys = keys;
   }
 
-  public AssociationAnalysis(ArrayList<AssociationResult> initialResults) {
-    res = new HashMap<String, AssociationResult>();
+  public AssociationAnalysis(AssociationKey keys, ArrayList<AssociationResult> initialResults) {
+    this.res = new HashMap<String, AssociationResult>();
+    this.keys = keys;
     for (AssociationResult association : initialResults) {
-      res.put(AssociationKey.getKey(association), association);
+      res.put(keys.getKey(association), association);
     }
   }
 
@@ -35,11 +38,11 @@ public class AssociationAnalysis {
 
   /** Updates the result array with the new entity mention given */
   private void updateScore(HashMap<String, AssociationResult> res, EntitySentiment sentiment) {
-    AssociationResult association = res.get(AssociationKey.getKey(sentiment));
+    AssociationResult association = res.get(keys.getKey(sentiment));
     if (association != null) {
       association.updateResult(sentiment);
     } else {
-      res.put(AssociationKey.getKey(sentiment), new AssociationResult(sentiment));
+      res.put(keys.getKey(sentiment), new AssociationResult(sentiment));
     }
   }
 }

--- a/capstone/src/main/java/com/google/sps/AssociationAnalysis.java
+++ b/capstone/src/main/java/com/google/sps/AssociationAnalysis.java
@@ -10,11 +10,16 @@ public class AssociationAnalysis {
   private HashMap<String, AssociationResult> res;
   private AssociationKey keys;
 
+  /** @param keys object that generates keys from sentiments, association results, and strings */
   public AssociationAnalysis(AssociationKey keys) {
     this.res = new HashMap<String, AssociationResult>();
     this.keys = keys;
   }
 
+  /**
+   * @param keys object that generates keys from sentiments, association results, and strings
+   * @param initialResults previous association results from old data to build on
+   */
   public AssociationAnalysis(AssociationKey keys, ArrayList<AssociationResult> initialResults) {
     this.res = new HashMap<String, AssociationResult>();
     this.keys = keys;

--- a/capstone/src/main/java/com/google/sps/AssociationDatastore.java
+++ b/capstone/src/main/java/com/google/sps/AssociationDatastore.java
@@ -1,0 +1,104 @@
+package com.google.sps;
+
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.Key;
+import com.google.appengine.api.datastore.PreparedQuery;
+import com.google.appengine.api.datastore.Query;
+import com.google.sps.data.MapData;
+import java.util.ArrayList;
+import java.util.Optional;
+
+/** Does all datastore operations related to associations */
+public class AssociationDatastore {
+
+  public static final String SURVEY_ENTITY_KIND = "Response";
+  public static final String COMMENT_PROPERTY = "text";
+  public static final String ZIPCODE = "zipCode";
+
+  private MapData mapData = new MapData();
+  private DatastoreService datastore;
+
+  /** @param datastore the datastore client */
+  public AssociationDatastore(DatastoreService datastore) {
+    this.datastore = datastore;
+  }
+
+  /**
+   * Get the survey comment text from datastore
+   *
+   * @return an arraylist of the comment text
+   */
+  public ArrayList<AssociationInput> getComments() {
+    Query query = new Query(SURVEY_ENTITY_KIND);
+    PreparedQuery results = datastore.prepare(query);
+
+    ArrayList<AssociationInput> comments = new ArrayList<AssociationInput>();
+    for (Entity e : results.asIterable()) {
+      if (e.getProperty("association-processed") == null
+          || !((boolean) e.getProperty("association-processed"))) {
+        String message = (String) e.getProperty(COMMENT_PROPERTY);
+        try {
+          ArrayList<String> scope = mapData.getScope((String) e.getProperty(ZIPCODE));
+          comments.add(new AssociationInput(message, scope));
+          e.setProperty("association-processed", true);
+          datastore.put(e);
+        } catch (NullPointerException exception) {
+          System.err.println("Invalid zip code in response: " + (String) e.getProperty(ZIPCODE));
+        }
+      }
+    }
+    return comments;
+  }
+
+  /**
+   * Loads all previous association results from datastore
+   *
+   * @param scope the scope to load results from
+   * @return an arraylist of previous responses
+   */
+  public ArrayList<AssociationResult> loadPreviousResults(String scope) {
+    Query query = new Query(AssociationResult.ENTITY_KIND);
+    PreparedQuery results = datastore.prepare(query);
+
+    ArrayList<AssociationResult> prev = new ArrayList<AssociationResult>();
+    for (Entity entity : results.asIterable()) {
+      if (!scope.equals((String) entity.getProperty("scope"))) continue;
+      String content = (String) entity.getProperty("name");
+      float weight = (float) (double) entity.getProperty("weight");
+      float score = (float) (double) entity.getProperty("score");
+      boolean strongSentiment = (boolean) entity.getProperty("strong-sentiment");
+      Key key = entity.getKey();
+      prev.add(new AssociationResult(content, score, weight, strongSentiment, key));
+    }
+
+    return prev;
+  }
+
+  /**
+   * Adds new association results to the datastore service
+   *
+   * @param res the arraylist of results to be stored
+   * @param scope the precinct/scope to store the results under
+   */
+  public void storeResults(ArrayList<AssociationResult> res, String scope) {
+    ArrayList<Entity> entities = new ArrayList<Entity>();
+    for (AssociationResult association : res) {
+      Optional<Key> key = association.getKey();
+      Entity entity;
+      if (key.isPresent()) {
+        entity = new Entity(key.get());
+      } else {
+        entity = new Entity(AssociationResult.ENTITY_KIND);
+      }
+      entity.setProperty("name", association.getContent());
+      entity.setProperty("score", association.getScore());
+      entity.setProperty("weight", association.getWeight());
+      entity.setProperty("average-sentiment", association.getAverageSentiment());
+      entity.setProperty("strong-sentiment", association.hasStrongSentiment());
+      entity.setProperty("scope", scope);
+      entities.add(entity);
+    }
+    datastore.put(entities);
+  }
+}

--- a/capstone/src/main/java/com/google/sps/AssociationDatastore.java
+++ b/capstone/src/main/java/com/google/sps/AssociationDatastore.java
@@ -37,15 +37,15 @@ public class AssociationDatastore {
     for (Entity e : results.asIterable()) {
       if (e.getProperty("association-processed") == null
           || !((boolean) e.getProperty("association-processed"))) {
-        String message = (String) e.getProperty(COMMENT_PROPERTY);
-        try {
-          ArrayList<String> scope = mapData.getScope((String) e.getProperty(ZIPCODE));
-          comments.add(new AssociationInput(message, scope));
-          e.setProperty("association-processed", true);
-          datastore.put(e);
-        } catch (NullPointerException exception) {
-          System.err.println("Invalid zip code in response: " + (String) e.getProperty(ZIPCODE));
+        if (e.getProperty(ZIPCODE) == null) {
+          System.err.println(
+              "No zipcode property on entity with id " + e.getProperty("id").toString());
         }
+        String message = (String) e.getProperty(COMMENT_PROPERTY);
+        ArrayList<String> scope = mapData.getScope((String) e.getProperty(ZIPCODE));
+        comments.add(new AssociationInput(message, scope));
+        e.setProperty("association-processed", true);
+        datastore.put(e);
       }
     }
     return comments;

--- a/capstone/src/main/java/com/google/sps/AssociationInput.java
+++ b/capstone/src/main/java/com/google/sps/AssociationInput.java
@@ -28,4 +28,16 @@ public class AssociationInput {
   public ArrayList<String> getScopes() {
     return scopes;
   }
+
+  public String toString() {
+    return "{" + message + ", " + scopes.toString() + "}";
+  }
+
+  public boolean equals(Object obj) {
+    if (obj == null || !AssociationInput.class.isAssignableFrom(obj.getClass())) {
+      return false;
+    }
+    AssociationInput x = (AssociationInput) obj;
+    return x.getMessage().equals(message) && x.getScopes().equals(scopes);
+  }
 }

--- a/capstone/src/main/java/com/google/sps/AssociationKey.java
+++ b/capstone/src/main/java/com/google/sps/AssociationKey.java
@@ -2,7 +2,7 @@ package com.google.sps;
 
 import opennlp.tools.stemmer.PorterStemmer;
 
-/** Generates lowercase no spaces word stems for keys in the AssociationResults hashmap */
+/** Generates keys in the Hashmap used to store entity sentiments and their associations */
 public class AssociationKey {
 
   private static PorterStemmer stemmer;

--- a/capstone/src/main/java/com/google/sps/AssociationKey.java
+++ b/capstone/src/main/java/com/google/sps/AssociationKey.java
@@ -5,13 +5,17 @@ import opennlp.tools.stemmer.PorterStemmer;
 /** Generates lowercase no spaces word stems for keys in the AssociationResults hashmap */
 public class AssociationKey {
 
-  private static PorterStemmer stemmer = new PorterStemmer();
+  private static PorterStemmer stemmer;
+
+  public AssociationKey() {
+    stemmer = new PorterStemmer();
+  }
 
   /**
    * @param content the word/phrase that makes up an association
    * @return the lowercase root for use as a key in a hashmap
    */
-  public static String getKey(String content) {
+  public String getKey(String content) {
     return stemmer.stem(content.toLowerCase().trim());
   }
 
@@ -19,7 +23,7 @@ public class AssociationKey {
    * @param sentiment an entity sentiment to generate a key from
    * @return the lowercase root of the content for use as a key in a hashmap
    */
-  public static String getKey(EntitySentiment sentiment) {
+  public String getKey(EntitySentiment sentiment) {
     return getKey(sentiment.getContent());
   }
 
@@ -27,7 +31,7 @@ public class AssociationKey {
    * @param result the association result to generate a key from
    * @return the lowercase root of the content for use as a key in a hashmap
    */
-  public static String getKey(AssociationResult result) {
+  public String getKey(AssociationResult result) {
     return getKey(result.getContent());
   }
 }

--- a/capstone/src/main/java/com/google/sps/AssociationResult.java
+++ b/capstone/src/main/java/com/google/sps/AssociationResult.java
@@ -123,7 +123,14 @@ public class AssociationResult {
 
   @Override
   public String toString() {
-    return content + "(" + Float.toString(score) + ", " + Boolean.toString(strongSentiment) + ")";
+    return content
+        + "("
+        + Float.toString(score)
+        + ", "
+        + Float.toString(weight)
+        + ", "
+        + Boolean.toString(strongSentiment)
+        + ")";
   }
 
   @Override

--- a/capstone/src/main/java/com/google/sps/servlets/UpdateAssociationServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/UpdateAssociationServlet.java
@@ -27,6 +27,11 @@ public class UpdateAssociationServlet extends HttpServlet {
   private LanguageServiceClient nlpClient;
   private DatastoreService datastore;
   private MapData mapData = new MapData();
+  private AssociationKey keyGeneration;
+
+  public UpdateAssociationServlet() {
+    keyGeneration = new AssociationKey();
+  }
 
   public void init() throws ServletException {
     try {
@@ -45,7 +50,7 @@ public class UpdateAssociationServlet extends HttpServlet {
     ArrayList<EntitySentiment> sentiments = nlp.analyzeAssociations(getComments());
 
     for (String scope : mapData.getAllScopes()) {
-      AssociationAnalysis analysis = new AssociationAnalysis(loadPreviousResults(scope));
+      AssociationAnalysis analysis = new AssociationAnalysis(keyGeneration, loadPreviousResults(scope));
       ArrayList<EntitySentiment> filteredSentiment = new ArrayList<EntitySentiment>();
       for (EntitySentiment sentiment : sentiments) {
         if (sentiment.getScopes().contains(scope)) {

--- a/capstone/src/main/java/com/google/sps/servlets/UpdateAssociationServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/UpdateAssociationServlet.java
@@ -50,7 +50,8 @@ public class UpdateAssociationServlet extends HttpServlet {
     ArrayList<EntitySentiment> sentiments = nlp.analyzeAssociations(getComments());
 
     for (String scope : mapData.getAllScopes()) {
-      AssociationAnalysis analysis = new AssociationAnalysis(keyGeneration, loadPreviousResults(scope));
+      AssociationAnalysis analysis =
+          new AssociationAnalysis(keyGeneration, loadPreviousResults(scope));
       ArrayList<EntitySentiment> filteredSentiment = new ArrayList<EntitySentiment>();
       for (EntitySentiment sentiment : sentiments) {
         if (sentiment.getScopes().contains(scope)) {

--- a/capstone/src/main/java/com/google/sps/servlets/UpdateAssociationServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/UpdateAssociationServlet.java
@@ -1,16 +1,10 @@
 package com.google.sps;
 
-import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
-import com.google.appengine.api.datastore.Entity;
-import com.google.appengine.api.datastore.Key;
-import com.google.appengine.api.datastore.PreparedQuery;
-import com.google.appengine.api.datastore.Query;
 import com.google.cloud.language.v1.LanguageServiceClient;
 import com.google.sps.data.MapData;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Optional;
 import javax.servlet.ServletException;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
@@ -25,7 +19,7 @@ public class UpdateAssociationServlet extends HttpServlet {
   public static final String ZIPCODE = "zipCode";
 
   private LanguageServiceClient nlpClient;
-  private DatastoreService datastore;
+  private AssociationDatastore datastore;
   private MapData mapData = new MapData();
   private AssociationKey keyGeneration;
 
@@ -36,7 +30,7 @@ public class UpdateAssociationServlet extends HttpServlet {
   public void init() throws ServletException {
     try {
       nlpClient = LanguageServiceClient.create();
-      datastore = DatastoreServiceFactory.getDatastoreService();
+      datastore = new AssociationDatastore(DatastoreServiceFactory.getDatastoreService());
     } catch (IOException exception) {
       System.err.println(exception);
     }
@@ -47,11 +41,11 @@ public class UpdateAssociationServlet extends HttpServlet {
     response.setContentType("text/html;");
     CloudNLPAssociation nlp = new CloudNLPAssociation(nlpClient);
 
-    ArrayList<EntitySentiment> sentiments = nlp.analyzeAssociations(getComments());
+    ArrayList<EntitySentiment> sentiments = nlp.analyzeAssociations(datastore.getComments());
 
     for (String scope : mapData.getAllScopes()) {
       AssociationAnalysis analysis =
-          new AssociationAnalysis(keyGeneration, loadPreviousResults(scope));
+          new AssociationAnalysis(keyGeneration, datastore.loadPreviousResults(scope));
       ArrayList<EntitySentiment> filteredSentiment = new ArrayList<EntitySentiment>();
       for (EntitySentiment sentiment : sentiments) {
         if (sentiment.getScopes().contains(scope)) {
@@ -59,89 +53,11 @@ public class UpdateAssociationServlet extends HttpServlet {
         }
       }
       ArrayList<AssociationResult> res = analysis.calculateScores(filteredSentiment);
-      storeResults(res, scope);
+      datastore.storeResults(res, scope);
     }
   }
 
   public void destroy() {
     nlpClient.close();
-  }
-
-  /**
-   * Get the survey comment text from datastore
-   *
-   * @return an arraylist of the comment text
-   */
-  private ArrayList<AssociationInput> getComments() {
-    Query query = new Query(SURVEY_ENTITY_KIND);
-    PreparedQuery results = datastore.prepare(query);
-
-    ArrayList<AssociationInput> comments = new ArrayList<AssociationInput>();
-    for (Entity e : results.asIterable()) {
-      if (e.getProperty("association-processed") == null
-          || !((boolean) e.getProperty("association-processed"))) {
-        String message = (String) e.getProperty(COMMENT_PROPERTY);
-        try {
-          ArrayList<String> scope = mapData.getScope((String) e.getProperty(ZIPCODE));
-          comments.add(new AssociationInput(message, scope));
-          e.setProperty("association-processed", true);
-          datastore.put(e);
-        } catch (NullPointerException exception) {
-          System.err.println("Invalid zip code in response: " + (String) e.getProperty(ZIPCODE));
-        }
-      }
-    }
-    return comments;
-  }
-
-  /**
-   * Loads all previous association results from datastore
-   *
-   * @param scope the scope to load results from
-   * @return an arraylist of previous responses
-   */
-  private ArrayList<AssociationResult> loadPreviousResults(String scope) {
-    Query query = new Query(AssociationResult.ENTITY_KIND);
-    PreparedQuery results = datastore.prepare(query);
-
-    ArrayList<AssociationResult> prev = new ArrayList<AssociationResult>();
-    for (Entity entity : results.asIterable()) {
-      if (!scope.equals((String) entity.getProperty("scope"))) continue;
-      String content = (String) entity.getProperty("name");
-      float weight = (float) (double) entity.getProperty("weight");
-      float score = (float) (double) entity.getProperty("score");
-      boolean strongSentiment = (boolean) entity.getProperty("strong-sentiment");
-      Key key = entity.getKey();
-      prev.add(new AssociationResult(content, score, weight, strongSentiment, key));
-    }
-
-    return prev;
-  }
-
-  /**
-   * Adds new association results to the datastore service
-   *
-   * @param res the arraylist of results to be stored
-   * @param scope the precinct/scope to store the results under
-   */
-  private void storeResults(ArrayList<AssociationResult> res, String scope) {
-    ArrayList<Entity> entities = new ArrayList<Entity>();
-    for (AssociationResult association : res) {
-      Optional<Key> key = association.getKey();
-      Entity entity;
-      if (key.isPresent()) {
-        entity = new Entity(key.get());
-      } else {
-        entity = new Entity(AssociationResult.ENTITY_KIND);
-      }
-      entity.setProperty("name", association.getContent());
-      entity.setProperty("score", association.getScore());
-      entity.setProperty("weight", association.getWeight());
-      entity.setProperty("average-sentiment", association.getAverageSentiment());
-      entity.setProperty("strong-sentiment", association.hasStrongSentiment());
-      entity.setProperty("scope", scope);
-      entities.add(entity);
-    }
-    datastore.put(entities);
   }
 }

--- a/capstone/src/test/java/com/google/sps/AssociationAnalysisTest.java
+++ b/capstone/src/test/java/com/google/sps/AssociationAnalysisTest.java
@@ -3,6 +3,7 @@ package com.google.sps.servlet;
 import static org.junit.Assert.assertEquals;
 
 import com.google.sps.AssociationAnalysis;
+import com.google.sps.AssociationMockKey;
 import com.google.sps.AssociationResult;
 import com.google.sps.EntitySentiment;
 import java.util.ArrayList;
@@ -14,7 +15,7 @@ public class AssociationAnalysisTest extends Mockito {
 
   @Test
   public void testEmpty() throws Exception {
-    AssociationAnalysis analysis = new AssociationAnalysis();
+    AssociationAnalysis analysis = new AssociationAnalysis(new AssociationMockKey());
     ArrayList<AssociationResult> res = analysis.calculateScores(new ArrayList<EntitySentiment>());
     assertEquals(res, new ArrayList<AssociationResult>());
   }
@@ -27,7 +28,7 @@ public class AssociationAnalysisTest extends Mockito {
                 new EntitySentiment("test1", 0.5f, 0.5f),
                 new EntitySentiment("test2", 0.9f, -0.6f),
                 new EntitySentiment("test3", 0f, 1.0f)));
-    AssociationAnalysis analysis = new AssociationAnalysis();
+    AssociationAnalysis analysis = new AssociationAnalysis(new AssociationMockKey());
     ArrayList<AssociationResult> res = analysis.calculateScores(input);
     assertEquals(
         res,
@@ -47,7 +48,7 @@ public class AssociationAnalysisTest extends Mockito {
                 new EntitySentiment("test1", 0.9f, 0.6f),
                 new EntitySentiment("test2", 0f, 1.0f),
                 new EntitySentiment("test2", 1.0f, -1.0f)));
-    AssociationAnalysis analysis = new AssociationAnalysis();
+    AssociationAnalysis analysis = new AssociationAnalysis(new AssociationMockKey());
     ArrayList<AssociationResult> res = analysis.calculateScores(input);
     assertEquals(
         res,
@@ -67,7 +68,7 @@ public class AssociationAnalysisTest extends Mockito {
                 new EntitySentiment("test1", 0f, 1.0f),
                 new EntitySentiment("test2", 1.0f, 1.0f),
                 new EntitySentiment("test1", 0.4f, 0.1f)));
-    AssociationAnalysis analysis = new AssociationAnalysis();
+    AssociationAnalysis analysis = new AssociationAnalysis(new AssociationMockKey());
     ArrayList<AssociationResult> res = analysis.calculateScores(input);
     assertEquals(
         res,
@@ -87,7 +88,7 @@ public class AssociationAnalysisTest extends Mockito {
                 new EntitySentiment("test1", 0f, 1.0f),
                 new EntitySentiment("test1", 1.0f, 1.0f),
                 new EntitySentiment("test1", 0.4f, 0.1f)));
-    AssociationAnalysis analysis = new AssociationAnalysis();
+    AssociationAnalysis analysis = new AssociationAnalysis(new AssociationMockKey());
     ArrayList<AssociationResult> res = analysis.calculateScores(input);
     assertEquals(
         res, new ArrayList(Arrays.asList(new AssociationResult("test1", 1.83f, 2.8f, true))));
@@ -103,7 +104,7 @@ public class AssociationAnalysisTest extends Mockito {
                 new EntitySentiment("test1", 0f, 1.0f),
                 new EntitySentiment("test2", 1.0f, -1.0f),
                 new EntitySentiment("test3", 0.4f, 0.1f)));
-    AssociationAnalysis analysis = new AssociationAnalysis();
+    AssociationAnalysis analysis = new AssociationAnalysis(new AssociationMockKey());
     ArrayList<AssociationResult> res = analysis.calculateScores(input);
     assertEquals(
         res,
@@ -116,7 +117,7 @@ public class AssociationAnalysisTest extends Mockito {
 
   @Test(expected = NullPointerException.class)
   public void testNullExceptionThrown() {
-    AssociationAnalysis analysis = new AssociationAnalysis();
+    AssociationAnalysis analysis = new AssociationAnalysis(new AssociationMockKey());
     analysis.calculateScores(null);
   }
 }

--- a/capstone/src/test/java/com/google/sps/AssociationDatastoreTest.java
+++ b/capstone/src/test/java/com/google/sps/AssociationDatastoreTest.java
@@ -1,0 +1,76 @@
+package com.google.sps;
+
+import static org.junit.Assert.assertEquals;
+
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
+import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
+import java.util.ArrayList;
+import java.util.Arrays;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class AssociationDatastoreTest {
+
+  private final LocalServiceTestHelper helper =
+      new LocalServiceTestHelper(new LocalDatastoreServiceTestConfig());
+
+  @Before
+  public void setUp() {
+    helper.setUp();
+  }
+
+  @After
+  public void tearDown() {
+    helper.tearDown();
+  }
+
+  private void addComment(
+      DatastoreService datastore, String text, String zipCode, boolean associationProcessed) {
+    Entity entity = new Entity(AssociationDatastore.SURVEY_ENTITY_KIND);
+    entity.setProperty(AssociationDatastore.COMMENT_PROPERTY, text);
+    entity.setProperty(AssociationDatastore.ZIPCODE, zipCode);
+    entity.setProperty("association-processed", associationProcessed);
+    datastore.put(entity);
+  }
+
+  @Test
+  public void getCommentsEmptyTest() {
+    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+    AssociationDatastore association = new AssociationDatastore(datastore);
+    ArrayList<AssociationInput> input = association.getComments();
+    assertEquals(input, new ArrayList<AssociationInput>());
+  }
+
+  @Test
+  public void skipsProcessedEntriesTest() {
+    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+    addComment(datastore, "hi", "94123", true);
+    addComment(datastore, "test", "94124", true);
+    addComment(datastore, "testing", "94122", true);
+
+    AssociationDatastore association = new AssociationDatastore(datastore);
+    ArrayList<AssociationInput> input = association.getComments();
+    assertEquals(input, new ArrayList<AssociationInput>());
+  }
+
+  @Test
+  public void skipsProcessedReturnsNewTest() {
+    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+    addComment(datastore, "hi", "94123", true);
+    addComment(datastore, "test", "94124", false);
+    addComment(datastore, "testing", "94122", true);
+
+    AssociationDatastore association = new AssociationDatastore(datastore);
+    ArrayList<AssociationInput> input = association.getComments();
+    assertEquals(
+        input,
+        new ArrayList<AssociationInput>(
+            Arrays.asList(
+                new AssociationInput(
+                    "test", new ArrayList<String>(Arrays.asList("Bayview", "SF"))))));
+  }
+}

--- a/capstone/src/test/java/com/google/sps/AssociationDatastoreTest.java
+++ b/capstone/src/test/java/com/google/sps/AssociationDatastoreTest.java
@@ -1,6 +1,7 @@
 package com.google.sps;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
@@ -75,6 +76,13 @@ public class AssociationDatastoreTest {
                     "test", new ArrayList<String>(Arrays.asList("Bayview", "SF"))))));
   }
 
+  /**
+   * Calculates whether the list of results is a valid list of results (has at most one response per
+   * word
+   *
+   * @param results the list of results to be checked for validity
+   * @return whether the list is a valid list of results
+   */
   public boolean isValidAssociationDatastore(ArrayList<AssociationResult> results) {
     HashSet<String> seen = new HashSet<String>();
     for (AssociationResult result : results) {
@@ -97,7 +105,7 @@ public class AssociationDatastoreTest {
     AssociationDatastore association = new AssociationDatastore(datastore);
     association.storeResults(data, "SF");
     ArrayList<AssociationResult> retrieved = association.loadPreviousResults("SF");
-    assert (isValidAssociationDatastore(retrieved));
+    assertTrue("Has multiple results for the same word", isValidAssociationDatastore(retrieved));
     assertEquals(data, retrieved);
   }
 
@@ -112,7 +120,7 @@ public class AssociationDatastoreTest {
     AssociationDatastore association = new AssociationDatastore(datastore);
     association.storeResults(data, "Bayview");
     ArrayList<AssociationResult> retrieved = association.loadPreviousResults("SF");
-    assert (isValidAssociationDatastore(retrieved));
+    assertTrue("Has multiple results for the same word", isValidAssociationDatastore(retrieved));
     assertEquals(new ArrayList<AssociationResult>(), retrieved);
   }
 
@@ -128,7 +136,7 @@ public class AssociationDatastoreTest {
     association.storeResults(data, "SF");
     AssociationDatastore newAssociation = new AssociationDatastore(datastore);
     ArrayList<AssociationResult> retrieved = newAssociation.loadPreviousResults("SF");
-    assert (isValidAssociationDatastore(retrieved));
+    assertTrue("Has multiple results for the same word", isValidAssociationDatastore(retrieved));
     assertEquals(data, retrieved);
   }
 
@@ -143,11 +151,11 @@ public class AssociationDatastoreTest {
     AssociationDatastore association = new AssociationDatastore(datastore);
     association.storeResults(data, "SF");
     ArrayList<AssociationResult> retrieved = association.loadPreviousResults("SF");
-    assert (isValidAssociationDatastore(retrieved));
+    assertTrue("Has multiple results for the same word", isValidAssociationDatastore(retrieved));
     assertEquals(data, retrieved);
     association.storeResults(retrieved, "SF");
     retrieved = association.loadPreviousResults("SF");
-    assert (isValidAssociationDatastore(retrieved));
+    assertTrue("Has multiple results for the same word", isValidAssociationDatastore(retrieved));
     assertEquals(data, retrieved);
   }
 }

--- a/capstone/src/test/java/com/google/sps/AssociationMockKey.java
+++ b/capstone/src/test/java/com/google/sps/AssociationMockKey.java
@@ -1,11 +1,7 @@
 package com.google.sps;
 
-import com.google.sps.AssociationKey;
-import com.google.sps.AssociationResult;
-import com.google.sps.EntitySentiment;
-
 public class AssociationMockKey extends AssociationKey {
-  
+
   private String key;
 
   @Override

--- a/capstone/src/test/java/com/google/sps/AssociationMockKey.java
+++ b/capstone/src/test/java/com/google/sps/AssociationMockKey.java
@@ -1,0 +1,25 @@
+package com.google.sps;
+
+import com.google.sps.AssociationKey;
+import com.google.sps.AssociationResult;
+import com.google.sps.EntitySentiment;
+
+public class AssociationMockKey extends AssociationKey {
+  
+  private String key;
+
+  @Override
+  public String getKey(String content) {
+    return content;
+  }
+
+  @Override
+  public String getKey(AssociationResult result) {
+    return result.getContent();
+  }
+
+  @Override
+  public String getKey(EntitySentiment sentiment) {
+    return sentiment.getContent();
+  }
+}


### PR DESCRIPTION
New changes:
- Refactoring of datastore association code
- Tests for datastore interface

Known Issues:
- Fails on valid implementations because tests are not order agnostic for the ouput (issues with equality checks when trying to fix this, will be fixing in a future PR)